### PR TITLE
Dynamically download frameworks depending on the selected MCU

### DIFF
--- a/builder/frameworks/at32firmlib.py
+++ b/builder/frameworks/at32firmlib.py
@@ -13,13 +13,13 @@ bsp = board.get("build.bsp", "")
 
 env.SConscript("_bare.py")
 
-FRAMEWORK_DIR = platform.get_package_dir("framework-at32firmlib")
+FRAMEWORK_DIR = platform.get_package_dir("framework-%s-firmlib" % (bsp.lower()))
 assert isdir(FRAMEWORK_DIR)
 
-FRAMEWORK_LIB_DIR = join(FRAMEWORK_DIR, bsp + "_Firmware_Library", "libraries")
+FRAMEWORK_LIB_DIR = join(FRAMEWORK_DIR, "libraries")
 assert isdir(FRAMEWORK_LIB_DIR)
 
-FRAMEWORK_MIDDLEWARE_DIR = join(FRAMEWORK_DIR, bsp + "_Firmware_Library", "middlewares")
+FRAMEWORK_MIDDLEWARE_DIR = join(FRAMEWORK_DIR, "middlewares")
 env.Append(FMD=[FRAMEWORK_MIDDLEWARE_DIR])
 
 

--- a/platform.json
+++ b/platform.json
@@ -4,15 +4,10 @@
     "description": "Artery Technology Company, specializing in ARM® Cortex®-M4 MCU, is committed to take the lead in the 32-bit MCU industry with the support of high-end R&D technology, comprehensive silicon IP and professional integration experience.",
     "homepage": "https://www.arterychip.com/",
     "license": "Apache-2.0",
-    "keywords": [
-        "ARM",
-        "Cortex-M4",
-        "ArteryTek",
-        "AT32"
-    ],
+    "keywords": ["ARM", "Cortex-M4", "ArteryTek", "AT32"],
     "repository": {
-      "type": "git",
-      "url": "https://github.com/ArteryTek/platform-arterytekat32.git"
+        "type": "git",
+        "url": "https://github.com/ArteryTek/platform-arterytekat32.git"
     },
     "engines": {
         "platformio": "^5"
@@ -31,9 +26,60 @@
             "owner": "platformio",
             "version": ">=1.60301.0,<1.80000.0"
         },
-        "framework-at32firmlib": {
+        "framework-at32a403a-firmlib": {
             "type": "framework",
-            "version": "https://github.com/ArteryTek/framework-at32firmlib.git"
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32A403A_Firmware_Library.git"
+        },
+        "framework-at32f402_405-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F402_405_Firmware_Library.git"
+        },
+        "framework-at32f403a_407-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F403A_407_Firmware_Library.git"
+        },
+        "framework-at32f403-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F403_Firmware_Library.git"
+        },
+        "framework-at32f413-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F413_Firmware_Library.git"
+        },
+        "framework-at32f415-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F415_Firmware_Library.git"
+        },
+        "framework-at32f421-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F421_Firmware_Library.git"
+        },
+        "framework-at32f423-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F423_Firmware_Library.git"
+        },
+        "framework-at32f425-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F425_Firmware_Library.git"
+        },
+        "framework-at32f435_437-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32F435_437_Firmware_Library.git"
+        },
+        "framework-at32wb415-firmlib": {
+            "type": "framework",
+            "optional": true,
+            "version": "https://github.com/ArteryTek/AT32WB415_Firmware_Library.git"
         },
         "tool-openocd-at32": {
             "type": "uploader",

--- a/platform.py
+++ b/platform.py
@@ -26,6 +26,13 @@ class Arterytekat32Platform(PlatformBase):
     def configure_default_packages(self, variables, targets):
         board = variables.get("board")
         board_config = self.board_config(board)
+        board_bsp = board_config.get("build.bsp", "")
+
+        frameworks = variables.get("pioframework", [])
+        if "at32firmlib" in frameworks:
+            assert board_bsp, ("Missing BSP field for %s" % board)
+            bsp_package = "framework-%s-firmlib" % (board_bsp.lower())
+            self.frameworks["at32firmlib"]["package"] = bsp_package
 
         default_protocol = board_config.get("upload.protocol") or ""
         if variables.get("upload_protocol", default_protocol) == "dfu":


### PR DESCRIPTION
I mentioned here https://github.com/ArteryTek/framework-at32firmlib/issues/3 that the library version in this repository is currently behind the actual latest version. Therefore, I would like to propose a change to how the framework is being downloaded.

Instead of maintaining additional repository for the framework, I propose that we add `package.json` in each firmware library, then have the platform script download the required firmware library based on `board.bsp` variable, for each board. This provides the benefit of not having to bump the version in the framework repository every time there is a new change to one of the library. This is the same approach as STM32Cube framework.

For this change to work, every firmware libraries must have the `package.json` file, for example, https://github.com/ArteryTek/AT32F402_405_Firmware_Library/pull/1